### PR TITLE
bug fix in calculation of dastraperr

### DIFF
--- a/sixdeskdb/davsturns.py
+++ b/sixdeskdb/davsturns.py
@@ -146,7 +146,7 @@ def mk_da_vst(data,seed,tune,turnsl,turnstep):
     dawtraperrint   = np.abs(((ajtrap*(2*(mta_sigma**3)*np.sin(2*mta_angle))).sum())*angstep*ampstep)
     dawtraperr      = np.abs(1/4.*dawtrapint**(-3/4.))*dawtraperrint
     dastraperr      = ampstep/2
-    dastraperrepang = ((np.abs(np.diff(mta_sigma))).sum())/(2*angmax)
+    dastraperrepang = ((np.abs(np.diff(mta_sigma))).sum())/(2*(angmax+1))
     dastraperrepamp = ampstep/2
     dastraperrep    = np.sqrt(dastraperrepang**2+dastraperrepamp**2)
     # ---- simpson rule (simp)


### PR DESCRIPTION
Instead of dividing by the number of angles, we should divide by the number of angles+1, because one angular step is pi/(2*(N+1)) where N is the number of angles. 
